### PR TITLE
[feat] Introduce ExEssentials.BrazilianDocument with validation and formatting support

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -82,8 +82,7 @@
           # You can customize the priority of any check
           # Priority values are: `low, normal, high, higher`
           #
-          {Credo.Check.Design.AliasUsage,
-           [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
+          {Credo.Check.Design.AliasUsage, [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
           {Credo.Check.Design.TagFIXME, []},
           # You can also customize the exit_status of each check.
           # If you don't want TODO comments to cause `mix credo` to fail, just

--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,5 @@
-# Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  import_deps: [:ecto],
+  inputs: ["*.{ex,exs}", "{config,lib,test}/**/*.{ex,exs}"],
   line_length: 120
 ]

--- a/lib/brazilian_document/brazilian_document.ex
+++ b/lib/brazilian_document/brazilian_document.ex
@@ -1,0 +1,45 @@
+defmodule ExEssentials.BrazilianDocument do
+  @moduledoc """
+    Convenience module for validating and formatting Brazilian CPF and CNPJ documents.
+    This module delegates functionality to the appropriate modules:
+    - `ExEssentials.BrazilianDocument.Validator` for validation
+    - `ExEssentials.BrazilianDocument.Formatter` for formatting
+
+    Use this module when you want a simplified interface for handling CPF and CNPJ without needing to reference specific modules.
+
+    ## Examples
+
+        iex> ExEssentials.BrazilianDocument.valid?("09340933001")
+        true
+
+        iex> ExEssentials.BrazilianDocument.cnpj_valid?("09281987000134")
+        true
+
+        iex> ExEssentials.BrazilianDocument.format("76713868045")
+        "767.138.680-45"
+
+        iex> ExEssentials.BrazilianDocument.cnpj_format("87671632000165")
+        "87.671.632/0001-65"
+  """
+
+  alias ExEssentials.BrazilianDocument.Formatter
+  alias ExEssentials.BrazilianDocument.Validator
+
+  @spec format(document :: String.t()) :: String.t() | nil
+  defdelegate format(document), to: Formatter
+
+  @spec cpf_format(cpf :: String.t()) :: String.t() | nil
+  defdelegate cpf_format(cpf), to: Formatter
+
+  @spec cnpj_format(cnpj :: String.t()) :: String.t() | nil
+  defdelegate cnpj_format(cnpj), to: Formatter
+
+  @spec valid?(document :: String.t()) :: boolean()
+  defdelegate valid?(document), to: Validator
+
+  @spec cnpj_valid?(cnpj :: String.t()) :: boolean()
+  defdelegate cnpj_valid?(cnpj), to: Validator
+
+  @spec cpf_valid?(cpf :: String.t()) :: boolean()
+  defdelegate cpf_valid?(cpf), to: Validator
+end

--- a/lib/brazilian_document/changeset.ex
+++ b/lib/brazilian_document/changeset.ex
@@ -1,0 +1,99 @@
+defmodule ExEssentials.BrazilianDocument.Changeset do
+  @moduledoc """
+    Provides Ecto.Changeset validators for Brazilian CPF and CNPJ documents.
+
+    This module offers three helper functions to easily validate fields within an Ecto changeset:
+    - `validate_brazilian_document/3`: Automatically detects whether the field contains a CPF or CNPJ.
+    - `validate_cpf/3`: Specifically validates CPF numbers.
+    - `validate_cnpj/3`: Specifically validates CNPJ numbers.
+
+    ## Examples
+        import Ecto.Changeset
+
+        alias ExEssentials.BrazilianDocument.Changeset
+
+        changeset =
+          %User{}
+          |> cast(%{"cpf" => "39053344705"}, [:cpf])
+          |> Changeset.validate_cpf(:cpf)
+
+        changeset.valid?
+        #=> true
+  """
+
+  alias Ecto.Changeset
+  alias ExEssentials.BrazilianDocument.Validator
+
+  @doc """
+    Validates a field as either CPF or CNPJ, depending on the value.
+    Uses `ExEssentials.BrazilianDocument.Validator.valid?/1` under the hood.
+
+    ## Parameters
+      - changeset: an `Ecto.Changeset` struct.
+      - field: the atom representing the field name.
+      - opts: an optional keyword list. Accepts `:message` to override the default error message.
+
+    ## Examples
+        iex> validate_brazilian_document(changeset, :document)
+        iex> validate_brazilian_document(changeset, :document, message: "is invalid")
+  """
+  @spec validate_brazilian_document(changeset :: Changeset.t(), field :: atom(), opts :: keyword()) :: Changeset.t()
+  def validate_brazilian_document(changeset, field, opts \\ []) when is_atom(field) do
+    Changeset.validate_change(changeset, field, fn _, value ->
+      if Validator.valid?(value) do
+        []
+      else
+        message = Keyword.get(opts, :message, "is not a valid Brazilian document")
+        [{field, message}]
+      end
+    end)
+  end
+
+  @doc """
+    Validates a field as a valid CNPJ (Cadastro Nacional da Pessoa Jurídica).
+
+    ## Parameters
+      - changeset: an `Ecto.Changeset` struct.
+      - field: the atom representing the field name.
+      - opts: an optional keyword list. Accepts `:message` to override the default error message.
+
+    ## Examples
+        iex> validate_cnpj(changeset, :company_cnpj)
+        iex> validate_cnpj(changeset, :company_cnpj, message: "is invalid")
+  """
+  @spec validate_cnpj(changeset :: Changeset.t(), field :: atom(), opts :: keyword()) :: Changeset.t()
+  def validate_cnpj(changeset, field, opts \\ []) when is_atom(field) do
+    Changeset.validate_change(changeset, field, fn _, value ->
+      if Validator.cnpj_valid?(value) do
+        []
+      else
+        message = Keyword.get(opts, :message, "is not a valid CNPJ")
+        [{field, message}]
+      end
+    end)
+  end
+
+  @doc """
+    Validates a field as a valid CPF (Cadastro de Pessoas Físicas).
+
+    ## Parameters
+      - changeset: an `Ecto.Changeset` struct.
+      - field: the atom representing the field name.
+      - opts: an optional keyword list. Accepts `:message` to override the default error message.
+
+    ## Examples
+        iex> validate_cpf(changeset, :cpf)
+        iex> validate_cpf(changeset, :cpf, message: "is invalid")
+  """
+  @spec validate_cpf(changeset :: Changeset.t(), field :: atom(), opts :: keyword()) :: Changeset.t()
+  def validate_cpf(changeset, field, opts \\ []) when is_atom(field) do
+    Changeset.validate_change(changeset, field, fn _, value ->
+      if Validator.cpf_valid?(value) do
+        []
+      else
+        message = Keyword.get(opts, :message, "is not a valid CPF")
+        [{field, message}]
+      end
+    end)
+  end
+end

--- a/lib/brazilian_document/formatter.ex
+++ b/lib/brazilian_document/formatter.ex
@@ -1,0 +1,125 @@
+defmodule ExEssentials.BrazilianDocument.Formatter do
+  @moduledoc """
+    Provides formatting for Brazilian CPF and CNPJ documents, including support for alphanumeric CNPJs.
+    This module exposes functions to format CPF and CNPJ numbers by applying the standard visual pattern used in Brazil.
+
+    ## Examples
+        iex> ExEssentials.BrazilianDocument.Formatter.format("39053344705")
+        "390.533.447-05"
+
+        iex> ExEssentials.BrazilianDocument.Formatter.format("11222333000181")
+        "11.222.333/0001-81"
+
+        iex> ExEssentials.BrazilianDocument.Formatter.format("AB123CD456EF01")
+        nil
+
+    The `format/1` function detects the document type and calls the appropriate formatting function.
+  """
+
+  alias ExEssentials.BrazilianDocument.Validator
+
+  @cpf_regex ~r/^(\d{3})(\d{3})(\d{3})(\d{2})$/
+  @cnpj_regex ~r/^(\d{2})(\d{3})(\d{3})(\d{4})(\d{2})$/
+  @cnpj_alphanum_regex ~r/^([A-Z0-9]{2})([A-Z0-9]{3})([A-Z0-9]{3})([A-Z0-9]{4})(\d{2})$/
+  @alphanum_regex ~r/[^a-zA-Z0-9]/
+
+  @doc """
+    Formats a string as either CPF or CNPJ depending on its length.
+    It delegates to `cpf_format/1` or `cnpj_format/1` accordingly.
+
+    ## Parameters
+      - document: a string containing a CPF or CNPJ.
+
+    ## Returns
+      - A formatted document string if valid, otherwise `nil`.
+
+    ## Examples
+        iex> ExEssentials.BrazilianDocument.Formatter.format("44286185060")
+        "442.861.850-60"
+
+        iex> ExEssentials.BrazilianDocument.Formatter.format("63219659000153")
+        "63.219.659/0001-53"
+
+        iex> ExEssentials.BrazilianDocument.Formatter.format("12ABC34501DE38")
+        nil
+  """
+  @spec format(document :: String.t()) :: String.t() | nil
+  def format(document) when is_binary(document) do
+    cleaned = String.trim(document)
+
+    cond do
+      String.length(cleaned) == 11 -> cpf_format(cleaned)
+      String.length(cleaned) == 14 -> cnpj_format(cleaned)
+      true -> nil
+    end
+  end
+
+  @doc """
+    Formats a CPF string with dots and dash.
+    Only valid CPFs are formatted; otherwise, returns `nil`.
+
+    ## Parameters
+      - cpf: a string of 11 digits (formatted or not).
+
+    ## Examples
+        iex> ExEssentials.BrazilianDocument.Formatter.cpf_format("70694167096")
+        "706.941.670-96"
+
+        iex> ExEssentials.BrazilianDocument.Formatter.cpf_format("70694167099")
+        nil
+  """
+  @spec cpf_format(cpf :: String.t()) :: String.t() | nil
+  def cpf_format(cpf) when is_binary(cpf) do
+    digits = cpf |> extract_numeric_digits() |> Enum.join()
+    if Validator.cpf_valid?(digits), do: Regex.replace(@cpf_regex, digits, "\\1.\\2.\\3-\\4"), else: nil
+  end
+
+  @doc """
+    Formats a CNPJ string using the standard Brazilian notation.
+    Supports both numeric and alphanumeric CNPJs. Returns `nil` if the document is invalid.
+
+    ## Parameters
+      - cnpj: a numeric or alphanumeric CNPJ string.
+
+    ## Examples
+        iex> ExEssentials.BrazilianDocument.Formatter.cnpj_format("20495056000171")
+        "20.495.056/0001-71"
+
+        iex> ExEssentials.BrazilianDocument.Formatter.cnpj_format("12ABC34501DE35")
+        "12.ABC.345/01DE-35"
+
+        iex> ExEssentials.BrazilianDocument.Formatter.cnpj_format("20495056000172")
+        nil
+
+        iex> ExEssentials.BrazilianDocument.Formatter.cnpj_format("AB123CD456EF01")
+        nil
+  """
+  @spec cnpj_format(cnpj :: String.t()) :: String.t() | nil
+  def cnpj_format(cnpj) when is_binary(cnpj) do
+    if Regex.match?(@cnpj_alphanum_regex, cnpj) do
+      cnpj_alphanum_format(cnpj)
+    else
+      cnpj_numeric_format(cnpj)
+    end
+  end
+
+  defp cnpj_numeric_format(cnpj) when is_binary(cnpj) do
+    digits = cnpj |> extract_numeric_digits() |> Enum.join()
+    if Validator.cnpj_valid?(digits), do: Regex.replace(@cnpj_regex, digits, "\\1.\\2.\\3/\\4-\\5"), else: nil
+  end
+
+  defp cnpj_alphanum_format(cnpj) when is_binary(cnpj) do
+    cleaned = cnpj |> String.replace(@alphanum_regex, "") |> String.upcase()
+
+    if Validator.cnpj_valid?(cleaned),
+      do: Regex.replace(@cnpj_alphanum_regex, cleaned, "\\1.\\2.\\3/\\4-\\5"),
+      else: nil
+  end
+
+  defp extract_numeric_digits(doc) do
+    doc
+    |> String.replace(~r/[^0-9]/, "")
+    |> String.graphemes()
+    |> Enum.map(&String.to_integer/1)
+  end
+end

--- a/lib/brazilian_document/validator.ex
+++ b/lib/brazilian_document/validator.ex
@@ -48,7 +48,7 @@ defmodule ExEssentials.BrazilianDocument.Validator do
 
     Returns `true` if valid, `false` if invalid.
   """
-  @spec valid?(String.t()) :: boolean()
+  @spec valid?(document :: String.t()) :: boolean()
   def valid?(document) do
     cleaned = String.trim(document)
 
@@ -79,7 +79,7 @@ defmodule ExEssentials.BrazilianDocument.Validator do
         iex> ExEssentials.BrazilianDocument.Validator.cnpj_valid?("12ABC34501DE36")
         false
   """
-  @spec cnpj_valid?(String.t()) :: boolean()
+  @spec cnpj_valid?(cnpj :: String.t()) :: boolean()
   def cnpj_valid?(cnpj) when is_binary(cnpj) do
     if Regex.match?(@cnpj_alphanum_regex, cnpj) do
       cnpj_alphanum_valid?(cnpj)
@@ -103,7 +103,7 @@ defmodule ExEssentials.BrazilianDocument.Validator do
         iex> ExEssentials.BrazilianDocument.Validator.cpf_valid?("05859468091")
         true
   """
-  @spec cpf_valid?(String.t()) :: boolean()
+  @spec cpf_valid?(cpf :: String.t()) :: boolean()
   def cpf_valid?(cpf) when is_binary(cpf) do
     with digits when length(digits) == 11 <- extract_numeric_digits(cpf),
          false <- repeated_digits?(digits) do

--- a/lib/brazilian_document/validator.ex
+++ b/lib/brazilian_document/validator.ex
@@ -1,0 +1,182 @@
+defmodule ExEssentials.BrazilianDocument.Validator do
+  @moduledoc """
+    Provides validation for Brazilian CPF and CNPJ documents, including support for alphanumeric CNPJs.
+    This module can be used to validate individual CPF or CNPJ numbers, with or without formatting characters.
+
+    ## Examples
+        iex> ExEssentials.BrazilianDocument.Validator.valid?("26944480000132")
+        true
+
+        iex> ExEssentials.BrazilianDocument.Validator.valid?("26944480000132")
+        true
+
+        iex> ExEssentials.BrazilianDocument.Validator.valid?("12ABC34501DE35")
+        true
+
+        iex> ExEssentials.BrazilianDocument.Validator.valid?("48335092029")
+        false
+
+        iex> ExEssentials.BrazilianDocument.Validator.valid?("26944480000133")
+        false
+
+        iex> ExEssentials.BrazilianDocument.Validator.valid?("AB123CD456EF01")
+        false
+
+    The `valid?/1` function will automatically detect whether the given document is a CPF or CNPJ based on its length.
+  """
+  @first_weights_cnpj [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+  @second_weights_cnpj [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2]
+  @first_weights_cpf [10, 9, 8, 7, 6, 5, 4, 3, 2]
+  @second_weights_cpf [11, 10, 9, 8, 7, 6, 5, 4, 3, 2]
+  @alphanum_regex ~r/[^a-zA-Z0-9]/
+  @cnpj_alphanum_regex ~r/^([A-Z0-9]{2})([A-Z0-9]{3})([A-Z0-9]{3})([A-Z0-9]{4})(\d{2})$/
+
+  @doc """
+    Determines if a given string is a valid CPF or CNPJ.
+    It strips whitespace and delegates to the appropriate validation function based on document length.
+
+    ## Parameters
+      - document: a string containing a CPF or CNPJ, with or without formatting.
+
+    ## Examples
+
+        iex> ExEssentials.BrazilianDocument.Validator.valid?("16664593051")
+        false
+
+        iex> ExEssentials.BrazilianDocument.Validator.valid?("16664593050")
+        true
+
+    Returns `true` if valid, `false` if invalid.
+  """
+  @spec valid?(String.t()) :: boolean()
+  def valid?(document) do
+    cleaned = String.trim(document)
+
+    cond do
+      String.length(cleaned) == 11 -> cpf_valid?(cleaned)
+      String.length(cleaned) == 14 -> cnpj_valid?(cleaned)
+      true -> false
+    end
+  end
+
+  @doc """
+    Validates a CNPJ (Cadastro Nacional da Pessoa Jurídica), including support for alphanumeric formats.
+    It detects if the CNPJ is numeric or alphanumeric and applies the appropriate validation rules.
+
+    ## Parameters
+      - cnpj: a string containing a numeric or alphanumeric CNPJ.
+
+    ## Examples
+        iex> ExEssentials.BrazilianDocument.Validator.cnpj_valid?("78944804000136")
+        true
+
+        iex> ExEssentials.BrazilianDocument.Validator.cnpj_valid?("12ABC34501DE35")
+        true
+
+        iex> ExEssentials.BrazilianDocument.Validator.cnpj_valid?("78944804000137")
+        false
+
+        iex> ExEssentials.BrazilianDocument.Validator.cnpj_valid?("12ABC34501DE36")
+        false
+  """
+  @spec cnpj_valid?(String.t()) :: boolean()
+  def cnpj_valid?(cnpj) when is_binary(cnpj) do
+    if Regex.match?(@cnpj_alphanum_regex, cnpj) do
+      cnpj_alphanum_valid?(cnpj)
+    else
+      cnpj_numeric_valid?(cnpj)
+    end
+  end
+
+  @doc """
+    Validates a CPF (Cadastro de Pessoas Físicas).
+    The function extracts numeric digits, verifies check digits, and checks against known invalid repeated values.
+
+    ## Parameters
+      - cpf: a string containing a CPF, formatted or not.
+
+    ## Examples
+
+        iex> ExEssentials.BrazilianDocument.Validator.cpf_valid?("05859468092")
+        false
+
+        iex> ExEssentials.BrazilianDocument.Validator.cpf_valid?("05859468091")
+        true
+  """
+  @spec cpf_valid?(String.t()) :: boolean()
+  def cpf_valid?(cpf) when is_binary(cpf) do
+    with digits when length(digits) == 11 <- extract_numeric_digits(cpf),
+         false <- repeated_digits?(digits) do
+      base = Enum.slice(digits, 0..8)
+      digits == append_cpf_digits(base)
+    else
+      _ -> false
+    end
+  end
+
+  defp cnpj_numeric_valid?(cnpj) when is_binary(cnpj) do
+    with digits when length(digits) == 14 <- extract_numeric_digits(cnpj),
+         false <- repeated_digits?(digits) do
+      base = Enum.slice(digits, 0..11)
+      digits == append_cnpj_digits(base)
+    else
+      _ -> false
+    end
+  end
+
+  defp cnpj_alphanum_valid?(cnpj) when is_binary(cnpj) do
+    cleaned = cnpj |> String.replace(@alphanum_regex, "") |> String.upcase()
+
+    with {base, dv} <- String.split_at(cleaned, 12),
+         true <- byte_size(base) == 12 and byte_size(dv) == 2,
+         graphemes = String.graphemes(base),
+         false <- repeated_chars?(graphemes),
+         true <- valid_alphanum_chars?(graphemes),
+         dv1 <- calculate_dv(graphemes, @first_weights_cnpj),
+         dv2 <- calculate_dv(graphemes ++ [Integer.to_string(dv1)], @second_weights_cnpj) do
+      "#{dv1}#{dv2}" == dv
+    else
+      _ -> false
+    end
+  end
+
+  defp calculate_dv(chars, weights) do
+    values = Enum.map(chars, &to_numeric_value/1)
+    sum = values |> Enum.zip(weights) |> Enum.map(&product_of_pair/1) |> Enum.sum()
+    rem = rem(sum, 11)
+    if rem < 2, do: 0, else: 11 - rem
+  end
+
+  defp product_of_pair({value, weight}), do: value * weight
+
+  defp to_numeric_value(<<char::utf8>>), do: char - ?0
+  defp to_numeric_value(int) when is_integer(int), do: int
+
+  defp append_cnpj_digits(base) do
+    d1 = calculate_dv(base, @first_weights_cnpj)
+    d2 = calculate_dv(base ++ [d1], @second_weights_cnpj)
+    base ++ [d1, d2]
+  end
+
+  defp append_cpf_digits(base) do
+    d1 = calculate_dv(base, @first_weights_cpf)
+    d2 = calculate_dv(base ++ [d1], @second_weights_cpf)
+    base ++ [d1, d2]
+  end
+
+  defp extract_numeric_digits(doc) do
+    doc
+    |> String.replace(~r/[^0-9]/, "")
+    |> String.graphemes()
+    |> Enum.map(&String.to_integer/1)
+  end
+
+  defp repeated_digits?([]), do: false
+  defp repeated_digits?(digits), do: Enum.uniq(digits) == [hd(digits)]
+
+  defp repeated_chars?([]), do: false
+  defp repeated_chars?(chars), do: Enum.uniq(chars) == [hd(chars)]
+
+  defp valid_alphanum_chars?(chars),
+    do: Enum.all?(chars, fn <<char::utf8>> -> char in ?0..?9 or char in ?A..?Z end)
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExEssentials.MixProject do
   def project do
     [
       app: :ex_essentials,
-      version: "0.4.2",
+      version: "0.5.0",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,

--- a/test/brazilian_document/brazilian_document_test.exs
+++ b/test/brazilian_document/brazilian_document_test.exs
@@ -1,0 +1,4 @@
+defmodule ExEssentials.BrazilianDocumentTest do
+  use ExUnit.Case
+  doctest ExEssentials.BrazilianDocument
+end

--- a/test/brazilian_document/changeset_test.exs
+++ b/test/brazilian_document/changeset_test.exs
@@ -1,0 +1,159 @@
+defmodule ExEssentials.BrazilianDocument.ChangesetTest do
+  use ExUnit.Case
+
+  import ExEssentials.BrazilianDocument.Changeset
+
+  defmodule Client do
+    use Ecto.Schema
+
+    import Ecto.Changeset
+
+    @fields ~w(name document)a
+
+    schema "clients" do
+      field :name, :string
+      field :document, :string
+    end
+
+    def changeset(attrs) do
+      %Client{}
+      |> cast(attrs, @fields)
+      |> validate_required(@fields)
+    end
+  end
+
+  describe "validate_brazilian_document/3" do
+    setup do
+      attrs = %{name: "John Doe", document: "52423987013"}
+      %{attrs: attrs}
+    end
+
+    test "should return %Changeset{valid?: true} when given a valid CPF",
+         %{attrs: attrs} do
+      assert changeset = attrs |> Client.changeset() |> validate_brazilian_document(:document)
+      assert changeset.valid?
+    end
+
+    test "should return %Changeset{valid?: true} when given a valid CNPJ",
+         %{attrs: attrs} do
+      attrs = Map.put(attrs, :document, "81415129000162")
+      assert changeset = attrs |> Client.changeset() |> validate_brazilian_document(:document)
+      assert changeset.valid?
+    end
+
+    test "should return %Changeset{valid?: true} when given a valid alphanumeric CNPJ",
+         %{attrs: attrs} do
+      attrs = Map.put(attrs, :document, "12ABC34501DE35")
+      assert changeset = attrs |> Client.changeset() |> validate_brazilian_document(:document)
+      assert changeset.valid?
+    end
+
+    test "should return %Changeset{valid?: false} when given an invalid CPF",
+         %{attrs: attrs} do
+      attrs = Map.put(attrs, :document, "12345678901")
+      assert changeset = attrs |> Client.changeset() |> validate_brazilian_document(:document)
+      refute changeset.valid?
+      assert [document: {"is not a valid Brazilian document", []}] == changeset.errors
+    end
+
+    test "should return %Changeset{valid?: false} when given an invalid CNPJ",
+         %{attrs: attrs} do
+      attrs = Map.put(attrs, :document, "02345678000195")
+      assert changeset = attrs |> Client.changeset() |> validate_brazilian_document(:document)
+      refute changeset.valid?
+      assert [document: {"is not a valid Brazilian document", []}] == changeset.errors
+    end
+
+    test "should return %Changeset{valid?: false} when given an invalid alphanumeric CNPJ",
+         %{attrs: attrs} do
+      attrs = Map.put(attrs, :document, "12ABC34501DE38")
+      assert changeset = attrs |> Client.changeset() |> validate_brazilian_document(:document)
+      refute changeset.valid?
+      assert [document: {"is not a valid Brazilian document", []}] == changeset.errors
+    end
+
+    test "should return %Changeset{valid?: false} when given an invalid document and custom message",
+         %{attrs: attrs} do
+      attrs = Map.put(attrs, :document, "12345678901")
+      opts = [message: "is invalid"]
+      assert changeset = attrs |> Client.changeset() |> validate_brazilian_document(:document, opts)
+      refute changeset.valid?
+      assert [document: {"is invalid", []}] == changeset.errors
+    end
+  end
+
+  describe "validate_cnpj/3" do
+    setup do
+      attrs = %{name: "John Doe", document: "81415129000162"}
+      %{attrs: attrs}
+    end
+
+    test "should return %Changeset{valid?: true} when given a valid CNPJ",
+         %{attrs: attrs} do
+      assert changeset = attrs |> Client.changeset() |> validate_cnpj(:document)
+      assert changeset.valid?
+    end
+
+    test "should return %Changeset{valid?: true} when given a valid alphanumeric CNPJ",
+         %{attrs: attrs} do
+      attrs = Map.put(attrs, :document, "12ABC34501DE35")
+      assert changeset = attrs |> Client.changeset() |> validate_cnpj(:document)
+      assert changeset.valid?
+    end
+
+    test "should return %Changeset{valid?: false} when given an invalid CNPJ",
+         %{attrs: attrs} do
+      attrs = Map.put(attrs, :document, "02345678000195")
+      assert changeset = attrs |> Client.changeset() |> validate_cnpj(:document)
+      refute changeset.valid?
+      assert [document: {"is not a valid CNPJ", []}] == changeset.errors
+    end
+
+    test "should return %Changeset{valid?: false} when given an invalid alphanumeric CNPJ",
+         %{attrs: attrs} do
+      attrs = Map.put(attrs, :document, "12ABC34501DE38")
+      assert changeset = attrs |> Client.changeset() |> validate_cnpj(:document)
+      refute changeset.valid?
+      assert [document: {"is not a valid CNPJ", []}] == changeset.errors
+    end
+
+    test "should return %Changeset{valid?: false} when given an invalid document and custom message",
+         %{attrs: attrs} do
+      attrs = Map.put(attrs, :document, "02345678000195")
+      opts = [message: "is invalid"]
+      assert changeset = attrs |> Client.changeset() |> validate_cnpj(:document, opts)
+      refute changeset.valid?
+      assert [document: {"is invalid", []}] == changeset.errors
+    end
+  end
+
+  describe "validate_cpf/3" do
+    setup do
+      attrs = %{name: "John Doe", document: "52423987013"}
+      %{attrs: attrs}
+    end
+
+    test "should return %Changeset{valid?: true} when given a valid CPF",
+         %{attrs: attrs} do
+      assert changeset = attrs |> Client.changeset() |> validate_cpf(:document)
+      assert changeset.valid?
+    end
+
+    test "should return %Changeset{valid?: false} when given an invalid CPF",
+         %{attrs: attrs} do
+      attrs = Map.put(attrs, :document, "12345678901")
+      assert changeset = attrs |> Client.changeset() |> validate_cpf(:document)
+      refute changeset.valid?
+      assert [document: {"is not a valid CPF", []}] == changeset.errors
+    end
+
+    test "should return %Changeset{valid?: false} when given an invalid document and custom message",
+         %{attrs: attrs} do
+      attrs = Map.put(attrs, :document, "12345678901")
+      opts = [message: "is invalid"]
+      assert changeset = attrs |> Client.changeset() |> validate_cpf(:document, opts)
+      refute changeset.valid?
+      assert [document: {"is invalid", []}] == changeset.errors
+    end
+  end
+end

--- a/test/brazilian_document/formatter_test.exs
+++ b/test/brazilian_document/formatter_test.exs
@@ -1,0 +1,88 @@
+defmodule ExEssentials.BrazilianDocument.FormatterTest do
+  use ExUnit.Case
+
+  doctest ExEssentials.BrazilianDocument.Formatter
+
+  alias ExEssentials.BrazilianDocument.Formatter
+
+  describe "format/1" do
+    test "should return formatted CPF when given a valid CPF" do
+      valid_cpf = "52423987013"
+      assert "524.239.870-13" == Formatter.format(valid_cpf)
+    end
+
+    test "should return formatted CPF when given a valid CPF that start with zero" do
+      valid_cpf = "04337459081"
+      assert "043.374.590-81" == Formatter.format(valid_cpf)
+    end
+
+    test "should return formatted CPF when given a valid CPF that starts with two zeros" do
+      valid_cpf = "00408719915"
+      assert "004.087.199-15" == Formatter.format(valid_cpf)
+    end
+
+    test "should return formatted CPF when given a valid CPF that start with three zeros" do
+      valid_cpf = "00036580589"
+      assert "000.365.805-89" == Formatter.format(valid_cpf)
+    end
+
+    test "should return formatted CNPJ when given a valid CNPJ" do
+      valid_cnpj = "81415129000162"
+      assert "81.415.129/0001-62" == Formatter.format(valid_cnpj)
+    end
+
+    test "should return formatted CNPJ when given a valid CNPJ that start with zero" do
+      valid_cnpj = "07205272000177"
+      assert "07.205.272/0001-77" == Formatter.format(valid_cnpj)
+    end
+
+    test "should return formatted CNPJ when given a valid CNPJ that starts with two zeros" do
+      valid_cnpj = "00895553000150"
+      assert "00.895.553/0001-50" == Formatter.format(valid_cnpj)
+    end
+
+    test "should return formatted CNPJ when given a valid CNPJ that start with three zeros" do
+      valid_cnpj = "00028986000108"
+      assert "00.028.986/0001-08" == Formatter.format(valid_cnpj)
+    end
+
+    test "should return formatted alphanumeric CNPJ when given a valid alphanumeric CNPJ" do
+      valid_cnpj = "12ABC34501DE35"
+      assert "12.ABC.345/01DE-35" == Formatter.format(valid_cnpj)
+    end
+
+    test "should return nil for invalid document length" do
+      invalid_document = "1234567890"
+      assert nil == Formatter.format(invalid_document)
+    end
+  end
+
+  describe "cpf_format/1" do
+    test "should return formatted CPF when given a valid CPF" do
+      valid_cpf = "52423987013"
+      assert "524.239.870-13" == Formatter.cpf_format(valid_cpf)
+    end
+
+    test "should return nil when given an invalid CPF" do
+      invalid_cpf = "12345678901"
+      assert nil == Formatter.cpf_format(invalid_cpf)
+    end
+  end
+
+  describe "cnpj_format/1" do
+    test "should return formatted CNPJ when given a valid CNPJ" do
+      valid_cnpj = "81415129000162"
+      assert "81.415.129/0001-62" == Formatter.cnpj_format(valid_cnpj)
+    end
+
+    test "should return formatted alphanumeric CNPJ when given a valid alphanumeric CNPJ" do
+      valid_cnpj = "12ABC34501DE35"
+      assert "12.ABC.345/01DE-35" == Formatter.cnpj_format(valid_cnpj)
+    end
+
+    test "should return nil when given an invalid CNPJ" do
+      invalid_cnpj = "02345678000195"
+      assert nil == Formatter.cnpj_format(invalid_cnpj)
+    end
+  end
+end

--- a/test/brazilian_document/validator_test.exs
+++ b/test/brazilian_document/validator_test.exs
@@ -1,0 +1,67 @@
+defmodule ExEssentials.BrazilianDocument.ValidatorTest do
+  use ExUnit.Case
+
+  doctest ExEssentials.BrazilianDocument.Validator
+
+  alias ExEssentials.BrazilianDocument.Validator
+
+  describe "valid?/1" do
+    test "should return true for valid CPF",
+      do: assert(Validator.valid?("52423987013"))
+
+    test "should return true for valid CPF numbers that start with zero",
+      do: assert(Validator.valid?("04337459081"))
+
+    test "should return true for a valid CPF that starts with two zeros",
+      do: assert(Validator.valid?("00408719915"))
+
+    test "should return true for a valid CPF that starts with three zeros",
+      do: assert(Validator.valid?("00036580589"))
+
+    test "should return true for valid CNPJ",
+      do: assert(Validator.valid?("81415129000162"))
+
+    test "should return true for valid CNPJ numbers that start with zero",
+      do: assert(Validator.valid?("07205272000177"))
+
+    test "should return true for valid CNPJ that starts with two zeros",
+      do: assert(Validator.valid?("00895553000150"))
+
+    test "should return true for valid CNPJ that starts with three zeros",
+      do: assert(Validator.valid?("00028986000108"))
+
+    test "should return true for valid alphanumeric CNPJ",
+      do: assert(Validator.valid?("12ABC34501DE35"))
+
+    test "should return false for invalid CPF",
+      do: refute(Validator.valid?("12345678901"))
+
+    test "should return false for invalid CNPJ",
+      do: refute(Validator.valid?("02345678000195"))
+
+    test "should return false for invalid document length",
+      do: refute(Validator.valid?("1234567890"))
+
+    test "should return false for invalid alphanumeric CNPJ",
+      do: refute(Validator.valid?("12ABC34501DE38"))
+  end
+
+  describe "cnpj_valid?/1" do
+    test "should return true for valid CNPJ",
+      do: assert(Validator.cnpj_valid?("81415129000162"))
+
+    test "should return true for valid alphanumeric CNPJ",
+      do: assert(Validator.cnpj_valid?("12ABC34501DE35"))
+
+    test "should return false for invalid CNPJ",
+      do: refute(Validator.cnpj_valid?("02345678000195"))
+  end
+
+  describe "cpf_valid?/1" do
+    test "should return true for valid CPF",
+      do: assert(Validator.cpf_valid?("52423987013"))
+
+    test "should return false for invalid CPF",
+      do: refute(Validator.cpf_valid?("12345678901"))
+  end
+end

--- a/test/support/validators/types/user/course.ex
+++ b/test/support/validators/types/user/course.ex
@@ -8,9 +8,9 @@ defmodule Support.Validators.Types.User.Course do
 
   @primary_key false
   embedded_schema do
-    field(:name, :string)
-    field(:duration, :integer)
-    field(:level, :string)
+    field :name, :string
+    field :duration, :integer
+    field :level, :string
   end
 
   def changeset(schema, params) do

--- a/test/support/validators/types/user/preferences.ex
+++ b/test/support/validators/types/user/preferences.ex
@@ -9,8 +9,8 @@ defmodule Support.Validators.Types.User.Preferences do
 
   @primary_key false
   embedded_schema do
-    field(:theme, :string)
-    field(:language, :string)
+    field :theme, :string
+    field :language, :string
   end
 
   def changeset(schema, params) do

--- a/test/support/validators/user.ex
+++ b/test/support/validators/user.ex
@@ -10,11 +10,11 @@ defmodule Support.Validators.User do
   @fields ~w(name email)a
 
   schema "users" do
-    field(:name, :string)
-    field(:email, :string)
+    field :name, :string
+    field :email, :string
 
-    embeds_one(:preferences, Preferences)
-    embeds_many(:courses, Course)
+    embeds_one :preferences, Preferences
+    embeds_many :courses, Course
   end
 
   def create(params) do


### PR DESCRIPTION
# ✨ Add Brazilian Document Utilities (Validation & Formatting)

This merge request introduces a suite of utilities for working with Brazilian documents (CPF and CNPJ), organized under the ExEssentials.BrazilianDocument namespace.

## ✅ Main Features
- Validation
- Support for both CPF and CNPJ formats
- Detection of document type based on input
- Alphanumeric CNPJ support
- Ecto Changeset validators: `validate_cpf/3`, `validate_cnpj/3`, and `validate_brazilian_document/3`
- Formatting
- Standard visual formatting for valid CPF and CNPJ
- Auto-detection via `format/1`
- Graceful fallback (nil) for invalid input
- Delegator Module
- ExEssentials.BrazilianDocument provides a simple and cohesive API by delegating to the internal Formatter and Validator modules

📚 Documentation
- All modules (Validator, Formatter, Changeset, and BrazilianDocument) are fully documented in English
- Includes detailed descriptions, parameter info, return values, and IEx-ready examples for all public functions

📌 Example Usage
```elixir
ExEssentials.BrazilianDocument.valid?("52962902081")
# => true

ExEssentials.BrazilianDocument.format("45541629000187")
# => "45.541.629/0001-87"

changeset
|> Changeset.validate_cpf(:cpf)
|> Changeset.validate_cnpj(:cnpj)
```