### PR TITLE
feat(runner): add recover/3 to intercept step errors and continue flow 🔄

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ by adding `ex_essentials` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:ex_essentials, "~> 0.9.1"}
+    {:ex_essentials, "~> 0.10.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ExEssentials.MixProject do
   def project do
     [
       app: :ex_essentials,
-      version: "0.9.1",
+      version: "0.10.0",
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,


### PR DESCRIPTION
# What

This PR adds `Runner.recover/3`, a fail-safe mechanism to intercept step failures and inject recovery steps, allowing the flow to continue when appropriate. 🧯✨

# Why

Our Runner is currently fail-fast (similar to `Ecto.Multi`): any {:error, reason} stops the flow immediately. In some cases (e.g., transient upstream errors), we want to recover, enqueue retries, notify, or apply compensations without duplicating orchestration logic. 🔁📦

# How
- Introduces a new step type: {:recover, predicate, on_error} 🧩
- Adds `recover/3` API:
   - predicate receives `{step, reason, changes_before}` and decides whether to recover ✅
    - `on_error` injects new steps into the pipeline 🧱
- Updates the executor so that when a step fails, it searches for the next matching `recover/3` and:
   - injects the recovery steps
   - continues with the remaining steps after that `recover/3` 🚀
- Keeps the original fail-fast behavior when no recovery matches 🛑

# Tests

## Added test coverage for:
- registering `recover/3` on non-failed runners ✅
- no-op behavior when runner is already failed ✅
- recovering from a failing sync step and continuing execution 🔄
- returning the original error when no recover matches 🧨
- failing with `{:duplicated_step_name, ...}` when recovery injects colliding step names 🚫

# Notes
- `recover/3` is opt-in and does not change existing flows unless explicitly used. 🙌

# Checklist
- `mix format --check-formatted` 🎨✅
- `mix test` ✅
- `mix credo` 🧹✅
- `mix dialyzer` 🧠
- No breaking changes 🚦